### PR TITLE
Terminated app location

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,44 @@ import 'package:background_locator/background_locator.dart';
             android:value="2" />
 ```
 
+3) If you need to call other plugins, even when the application is terminated, create the `Application.kt` file and add the necessary plugins to the `registerWith` function:
+```kotlin
+package rekab.app.background_locator_example
+
+import rekab.app.background_locator.LocatorService
+import io.flutter.app.FlutterApplication
+import io.flutter.plugin.common.PluginRegistry
+import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
+import io.flutter.plugins.pathprovider.PathProviderPlugin
+
+class Application : FlutterApplication(), PluginRegistrantCallback {
+    override fun onCreate() {
+        super.onCreate()
+        LocatorService.setPluginRegistrant(this)
+    }
+
+    override fun registerWith(registry: PluginRegistry?) {
+        if (!registry!!.hasPlugin("io.flutter.plugins.pathprovider")) {
+            PathProviderPlugin.registerWith(registry!!.registrarFor("io.flutter.plugins.pathprovider"))
+        }
+    }
+}
+```
+
+4) Then, call the plugins on the callback function instead of on the port listener:
+```dart
+import 'package:path_provider/path_provider.dart';
+
+static void callback(LocationDto locationDto) async {
+  print('location in dart: ${locationDto.toString()}');
+  final SendPort send = IsolateNameServer.lookupPortByName(_isolateName);
+  send?.send(locationDto);
+
+  final file = await _getTempLogFile();
+  await file.writeAsString(locationDto.toString(), mode: FileMode.append);
+}
+```
+
 ### iOS
 
 1) Add the following lines to `AppDelegate` class:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ class Application : FlutterApplication(), PluginRegistrantCallback {
 }
 ```
 
-4) Then, call the plugins on the callback function instead of on the port listener:
+4) And change the application class on `AndroidManifest.xml` to `.Application`:
+```xml
+<application
+        android:name="io.flutter.app.FlutterApplication"	        
+        android:name=".Application"
+```
+
+5) Then, call the plugins on the callback function instead of on the port listener:
 ```dart
 import 'package:path_provider/path_provider.dart';
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ static void callback(LocationDto locationDto) async {
 }
 ```
 
+**Note**: The steps above are required because the plugins are registered in the main isolate, which is killed when the application is terminated.
+
 ### iOS
 
 1) Add the following lines to `AppDelegate` class:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ class Application : FlutterApplication(), PluginRegistrantCallback {
 4) And change the application class on `AndroidManifest.xml` to `.Application`:
 ```xml
 <application
-        android:name="io.flutter.app.FlutterApplication"	        
         android:name=".Application"
 ```
 

--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android__</name>
+	<comment>Project android__ created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(6.0))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/usr/lib/jvm/java-8-openjdk-amd64
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/src/main/kotlin/rekab/app/background_locator/LocatorService.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/LocatorService.kt
@@ -8,6 +8,7 @@ import androidx.core.app.JobIntentService
 import com.google.android.gms.location.LocationResult
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.view.FlutterCallbackInformation
 import io.flutter.view.FlutterMain
 import io.flutter.view.FlutterNativeView
@@ -42,10 +43,17 @@ class LocatorService : MethodChannel.MethodCallHandler, JobIntentService() {
         private var backgroundFlutterView: FlutterNativeView? = null
         @JvmStatic
         private val serviceStarted = AtomicBoolean(false)
+        @JvmStatic
+        private var pluginRegistrantCallback: PluginRegistrantCallback? = null;
 
         @JvmStatic
         fun enqueueWork(context: Context, work: Intent) {
             enqueueWork(context, LocatorService::class.java, JOB_ID, work)
+        }
+
+        @JvmStatic
+        fun setPluginRegistrant(callback: PluginRegistrantCallback) {
+            pluginRegistrantCallback = callback
         }
     }
 
@@ -77,6 +85,8 @@ class LocatorService : MethodChannel.MethodCallHandler, JobIntentService() {
                 backgroundFlutterView!!.runFromBundle(args)
                 IsolateHolderService.setBackgroundFlutterView(backgroundFlutterView)
             }
+
+            pluginRegistrantCallback?.registerWith(backgroundFlutterView!!.pluginRegistry)
         }
 
         backgroundChannel = MethodChannel(backgroundFlutterView, BACKGROUND_CHANNEL_ID)

--- a/example/android/.project
+++ b/example/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android_</name>
+	<comment>Project android_ created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name=".Application"
         android:label="background_locator_example"
         android:icon="@mipmap/ic_launcher"
         >

--- a/example/android/app/src/main/kotlin/rekab/app/background_locator_example/Application.kt
+++ b/example/android/app/src/main/kotlin/rekab/app/background_locator_example/Application.kt
@@ -1,11 +1,9 @@
 package rekab.app.background_locator_example
 
-import rekab.app.background_locator.BackgroundLocatorPlugin
 import rekab.app.background_locator.LocatorService
 import io.flutter.app.FlutterApplication
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
-import io.flutter.plugins.GeneratedPluginRegistrant;
 import io.flutter.plugins.pathprovider.PathProviderPlugin
 
 class Application : FlutterApplication(), PluginRegistrantCallback {

--- a/example/android/app/src/main/kotlin/rekab/app/background_locator_example/Application.kt
+++ b/example/android/app/src/main/kotlin/rekab/app/background_locator_example/Application.kt
@@ -1,0 +1,22 @@
+package rekab.app.background_locator_example
+
+import rekab.app.background_locator.BackgroundLocatorPlugin
+import rekab.app.background_locator.LocatorService
+import io.flutter.app.FlutterApplication
+import io.flutter.plugin.common.PluginRegistry
+import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
+import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.plugins.pathprovider.PathProviderPlugin
+
+class Application : FlutterApplication(), PluginRegistrantCallback {
+    override fun onCreate() {
+        super.onCreate()
+        LocatorService.setPluginRegistrant(this)
+    }
+
+    override fun registerWith(registry: PluginRegistry?) {
+        if (!registry!!.hasPlugin("io.flutter.plugins.pathprovider")) {
+            PathProviderPlugin.registerWith(registry!!.registrarFor("io.flutter.plugins.pathprovider"))
+        }
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,7 +39,6 @@ class _MyAppState extends State<MyApp> {
 
     port.listen(
       (dynamic data) async {
-        await setLog(data);
         await updateUI(data);
       },
     );
@@ -65,7 +64,7 @@ class _MyAppState extends State<MyApp> {
         dp(locationDto.longitude, 4).toString();
   }
 
-  Future<void> setLog(LocationDto data) async {
+  static Future<void> setLog(LocationDto data) async {
     final date = DateTime.now();
     await FileManager.writeToLogFile(
         '${formatDateLog(date)} --> ${formatLog(data)}\n');
@@ -94,6 +93,7 @@ class _MyAppState extends State<MyApp> {
 
   static void callback(LocationDto locationDto) async {
     print('location in dart: ${locationDto.toString()}');
+    await setLog(locationDto);
     final SendPort send = IsolateNameServer.lookupPortByName(_isolateName);
     send?.send(locationDto);
   }


### PR DESCRIPTION
I believe this fix solves #20.

I haven't tested it on iOS yet (if this fix breaks the app on iOS), just on Android.

The fix is based on the creation of the application class for Android and adding mannualy the plugins that the location callback will invoke, even when the app is terminated.