### PR TITLE
Fix BackgroundLocatorPlugin.getCallbackHandle bug which caused some callbacks not getting executed

### DIFF
--- a/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
@@ -238,9 +238,10 @@ class BackgroundLocatorPlugin
         }
 
         @JvmStatic
-        fun getCallbackHandle(context: Context, key: String): Long {
-            return context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE)
-                    .getLong(key, 0)
+        fun getCallbackHandle(context: Context, key: String): Long? {
+            val sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE)
+            if (sharedPreferences.contains(key)) return sharedPreferences.getLong(key, 0L)
+            return null
         }
 
         @JvmStatic
@@ -318,7 +319,7 @@ class BackgroundLocatorPlugin
         }
 
         val notificationCallback = getCallbackHandle(activity!!, NOTIFICATION_CALLBACK_HANDLE_KEY)
-        if (notificationCallback > 0 && IsolateHolderService.backgroundFlutterView != null) {
+        if (notificationCallback != null && IsolateHolderService.backgroundFlutterView != null) {
             val backgroundChannel = MethodChannel(IsolateHolderService.backgroundFlutterView,
                     BACKGROUND_CHANNEL_ID)
             Handler(activity?.mainLooper)

--- a/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderService.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderService.kt
@@ -65,7 +65,7 @@ class IsolateHolderService : Service() {
             if (backgroundFlutterView != null && instance != null && !isSendedInit) {
                 val context = instance
                 val initCallback = BackgroundLocatorPlugin.getCallbackHandle(context!!, INIT_CALLBACK_HANDLE_KEY)
-                if (initCallback > 0) {
+                if (initCallback != null) {
                     val initialDataMap = BackgroundLocatorPlugin.getDataCallback(context, INIT_DATA_CALLBACK_KEY)
                     val backgroundChannel = MethodChannel(backgroundFlutterView,
                             BACKGROUND_CHANNEL_ID)
@@ -142,7 +142,7 @@ class IsolateHolderService : Service() {
         if (backgroundFlutterView != null) {
             val context = this
             val disposeCallback = BackgroundLocatorPlugin.getCallbackHandle(context, DISPOSE_CALLBACK_HANDLE_KEY)
-            if (disposeCallback > 0 && backgroundFlutterView != null) {
+            if (disposeCallback != null && backgroundFlutterView != null) {
                 val backgroundChannel = MethodChannel(backgroundFlutterView,
                         BACKGROUND_CHANNEL_ID)
                 Handler(context.mainLooper)

--- a/android/src/main/kotlin/rekab/app/background_locator/LocatorService.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/LocatorService.kt
@@ -140,7 +140,7 @@ class LocatorService : MethodChannel.MethodCallHandler, JobIntentService() {
                             ARG_HEADING to location.bearing,
                             ARG_TIME to location.time.toDouble())
 
-            val callback = BackgroundLocatorPlugin.getCallbackHandle(context, CALLBACK_HANDLE_KEY)
+            val callback = BackgroundLocatorPlugin.getCallbackHandle(context, CALLBACK_HANDLE_KEY) as Long
 
             val result: HashMap<Any, Any> =
                     hashMapOf(ARG_CALLBACK to callback,


### PR DESCRIPTION
Hey there, thanks for the great library!

When I was trying the library on Android, I noticed that some callbacks (in my case was `initCallback`) not getting called/executed. Later on I debugged that it is possible for a function handle to be less than zero.

Currently on the Android side, if the callback handle is a negative number, the callbacks won't be invoked.
In my cases, `initCallback` not getting invoked is a huge problem and causes the feature to be broken.

Can you please review this?

Here below I attached my screenshot while debugging the callback handle:
![Screen Shot 2020-07-10 at 04 09 19](https://user-images.githubusercontent.com/25892469/87092668-0e43d280-c266-11ea-82cd-8cf8e5dd8f25.png)
