### PR TITLE
Added support for big text in Android notification. This is useful if…

### DIFF
--- a/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
@@ -33,6 +33,7 @@ import rekab.app.background_locator.Keys.Companion.ARG_CALLBACK_DISPATCHER
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_CHANNEL_NAME
 import rekab.app.background_locator.Keys.Companion.ARG_DISTANCE_FILTER
 import rekab.app.background_locator.Keys.Companion.ARG_INTERVAL
+import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_BIG_MSG
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_CALLBACK
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_ICON
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_ICON_COLOR
@@ -115,6 +116,7 @@ class BackgroundLocatorPlugin
             intent.putExtra(ARG_NOTIFICATION_CHANNEL_NAME, settings[ARG_NOTIFICATION_CHANNEL_NAME] as String)
             intent.putExtra(ARG_NOTIFICATION_TITLE, settings[ARG_NOTIFICATION_TITLE] as String)
             intent.putExtra(ARG_NOTIFICATION_MSG, settings[ARG_NOTIFICATION_MSG] as String)
+            intent.putExtra(ARG_NOTIFICATION_BIG_MSG, settings[ARG_NOTIFICATION_BIG_MSG] as String)
             intent.putExtra(ARG_NOTIFICATION_ICON, settings[ARG_NOTIFICATION_ICON] as String)
             intent.putExtra(ARG_NOTIFICATION_ICON_COLOR, settings[ARG_NOTIFICATION_ICON_COLOR] as Long)
 

--- a/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderService.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderService.kt
@@ -17,6 +17,7 @@ import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_CHANNEL_NAME
 import rekab.app.background_locator.Keys.Companion.ARG_DISPOSE_CALLBACK
 import rekab.app.background_locator.Keys.Companion.ARG_INIT_CALLBACK
 import rekab.app.background_locator.Keys.Companion.ARG_INIT_DATA_CALLBACK
+import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_BIG_MSG
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_ICON
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_ICON_COLOR
 import rekab.app.background_locator.Keys.Companion.ARG_NOTIFICATION_MSG
@@ -83,6 +84,7 @@ class IsolateHolderService : Service() {
     private var notificationChannelName = "Flutter Locator Plugin";
     private var notificationTitle = "Start Location Tracking"
     private var notificationMsg = "Track location in background"
+    private var notificationBigMsg = "Background location is on to keep the app up-tp-date with your location. This is required for main features to work properly when the app is not running."
     private var notificationIconColor = 0
     private var icon = 0
     private var wakeLockTime = 60 * 60 * 1000L // 1 hour default wake lock time
@@ -113,6 +115,8 @@ class IsolateHolderService : Service() {
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
                 .setContentTitle(notificationTitle)
                 .setContentText(notificationMsg)
+                .setStyle(NotificationCompat.BigTextStyle()
+                        .bigText(notificationBigMsg))
                 .setSmallIcon(icon)
                 .setColor(notificationIconColor)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
@@ -172,6 +176,7 @@ class IsolateHolderService : Service() {
         notificationChannelName = intent.getStringExtra(ARG_NOTIFICATION_CHANNEL_NAME)
         notificationTitle = intent.getStringExtra(ARG_NOTIFICATION_TITLE)
         notificationMsg = intent.getStringExtra(ARG_NOTIFICATION_MSG)
+        notificationBigMsg = intent.getStringExtra(ARG_NOTIFICATION_BIG_MSG)
         val iconNameDefault = "ic_launcher"
         var iconName = intent.getStringExtra(ARG_NOTIFICATION_ICON)
         if (iconName == null || iconName.isEmpty()) {

--- a/android/src/main/kotlin/rekab/app/background_locator/Keys.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/Keys.kt
@@ -80,6 +80,8 @@ class Keys {
         @JvmStatic
         val ARG_NOTIFICATION_MSG = "notificationMsg"
         @JvmStatic
+        val ARG_NOTIFICATION_BIG_MSG = "notificationBigMsg"
+        @JvmStatic
         val ARG_NOTIFICATION_ICON = "notificationIcon"
 
         @JvmStatic

--- a/android/src/main/kotlin/rekab/app/background_locator/PreferencesManager.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/PreferencesManager.kt
@@ -52,6 +52,11 @@ class PreferencesManager {
                     .apply()
 
             sharedPreferences.edit()
+                    .putString(Keys.ARG_NOTIFICATION_BIG_MSG,
+                            settings[Keys.ARG_NOTIFICATION_BIG_MSG] as String)
+                    .apply()
+
+            sharedPreferences.edit()
                     .putString(Keys.ARG_NOTIFICATION_ICON,
                             settings[Keys.ARG_NOTIFICATION_ICON] as String)
                     .apply()
@@ -109,6 +114,9 @@ class PreferencesManager {
 
             settings[Keys.ARG_NOTIFICATION_MSG] =
                     sharedPreferences.getString(Keys.ARG_NOTIFICATION_MSG, "")
+
+            settings[Keys.ARG_NOTIFICATION_BIG_MSG] =
+                    sharedPreferences.getString(Keys.ARG_NOTIFICATION_BIG_MSG, "")
 
             settings[Keys.ARG_NOTIFICATION_ICON] =
                     sharedPreferences.getString(Keys.ARG_NOTIFICATION_ICON, "")

--- a/lib/keys.dart
+++ b/lib/keys.dart
@@ -35,6 +35,7 @@ class Keys {
   static const String ARG_NOTIFICATION_CHANNEL_NAME = 'notificationChannelName';
   static const String ARG_NOTIFICATION_TITLE = 'notificationTitle';
   static const String ARG_NOTIFICATION_MSG = 'notificationMsg';
+  static const String ARG_NOTIFICATION_BIG_MSG = 'notificationBigMsg';
   static const String ARG_NOTIFICATION_ICON = 'notificationIcon';
   static const String ARG_NOTIFICATION_ICON_COLOR = 'notificationIconColor';
   static const String ARG_WAKE_LOCK_TIME = 'wakeLockTime';

--- a/lib/location_settings.dart
+++ b/lib/location_settings.dart
@@ -24,6 +24,7 @@ class LocationSettings {
   final String notificationChannelName;
   final String notificationTitle;
   final String notificationMsg;
+  final String notificationBigMsg;
   final String notificationIcon;
   final Color notificationIconColor;
   final int wakeLockTime; //minutes
@@ -39,12 +40,14 @@ class LocationSettings {
   ///
   /// [notificationMsg] Message of notification. Only applies for android. Default is 'Track location in background'.
   ///
+  /// [notificationBigMsg] Message to be displayed in the expanded content area of the notification. Only applies for android. Default is 'Background location is on to keep the app up-tp-date with your location. This is required for main features to work properly when the app is not running.'.
+  ///
   /// [notificationIcon] Icon name for notification. Only applies for android. The icon should be in 'mipmap' Directory.
   /// Default is app icon. Icon must comply to android rules to be displayed (transparent background and black/white shape)
   ///
   /// [notificationIconColor] Icon color for notification from notification drawer. Only applies for android. Default color is grey.
   ///
-  /// [wakeLockTime] Time for living service in background in meter. Only applies in android. Default is 60 minute.
+  /// [wakeLockTime] Time for living service in background in minutes. Only applies in android. Default is 60 minute.
   ///
   /// [autoStop] If true locator will stop as soon as app goes to background.
   LocationSettings(
@@ -54,6 +57,7 @@ class LocationSettings {
       this.notificationChannelName = 'Location tracking',
       this.notificationTitle = 'Start Location Tracking',
       this.notificationMsg = 'Track location in background',
+      this.notificationBigMsg = 'Background location is on to keep the app up-tp-date with your location. This is required for main features to work properly when the app is not running.',
       this.notificationIcon = '',
       this.notificationIconColor = Colors.grey,
       this.wakeLockTime = 60,
@@ -67,6 +71,7 @@ class LocationSettings {
       Keys.ARG_NOTIFICATION_CHANNEL_NAME: notificationChannelName,
       Keys.ARG_NOTIFICATION_TITLE: notificationTitle,
       Keys.ARG_NOTIFICATION_MSG: notificationMsg,
+      Keys.ARG_NOTIFICATION_BIG_MSG: notificationBigMsg,
       Keys.ARG_NOTIFICATION_ICON: notificationIcon,
       Keys.ARG_NOTIFICATION_ICON_COLOR: notificationIconColor?.value,
       Keys.ARG_WAKE_LOCK_TIME: wakeLockTime,


### PR DESCRIPTION
Added support for big text in Android notification. This is useful if you need to display a long text to explain why the background location service is required and how it might affect app features. Current implementation of Android notification support 1 line text only.

Also fixed a typo in wakeLockTime description in location_settings.dart whereby I replaced (Time for living service in background in meter) with (Time for living service in background in minutes)