### PR TITLE
fix Exception occurred during the initialization of the flutter

### DIFF
--- a/ios/Classes/BackgroundLocatorPlugin.m
+++ b/ios/Classes/BackgroundLocatorPlugin.m
@@ -103,7 +103,8 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 #pragma mark LocatorPlugin Methods
 - (void) sendLocationEvent: (NSDictionary<NSString*,NSNumber*>*)location {
-    if (_callbackChannel == nil) {
+    NSString *isolateId = [_headlessRunner isolateId];
+    if (_callbackChannel == nil || isolateId == nil) {
         return;
     }
     
@@ -111,10 +112,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
                      kArgCallback : @([PreferencesManager getCallbackHandle:kCallbackKey]),
                      kArgLocation: location
                      };
-    @try {
-        [_callbackChannel invokeMethod:kBCMSendLocation arguments:map];
-    }
-    @catch (NSException *exception) {}
+    [_callbackChannel invokeMethod:kBCMSendLocation arguments:map];
 }
 
 - (instancetype)init:(NSObject<FlutterPluginRegistrar> *)registrar {

--- a/ios/Classes/BackgroundLocatorPlugin.m
+++ b/ios/Classes/BackgroundLocatorPlugin.m
@@ -111,7 +111,10 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
                      kArgCallback : @([PreferencesManager getCallbackHandle:kCallbackKey]),
                      kArgLocation: location
                      };
-    [_callbackChannel invokeMethod:kBCMSendLocation arguments:map];
+    @try {
+        [_callbackChannel invokeMethod:kBCMSendLocation arguments:map];
+    }
+    @catch (NSException *exception) {}
 }
 
 - (instancetype)init:(NSObject<FlutterPluginRegistrar> *)registrar {


### PR DESCRIPTION
i have same problem as #237 

iOS devices.
background_locator: 1.6.0+1-beta
flutter: 2.2.1

sometimes, app crash when launched. 

```
2021-06-09 08:19:21.006065+0900 Runner[33423:232150] *** Assertion failure in -[FlutterEngine sendOnChannel:message:binaryReply:], FlutterEngine.mm:799
2021-06-09 08:19:21.034245+0900 Runner[33423:232150] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Sending a message before the FlutterEngine has been run.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff20420af6 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007fff20177e78 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff2042091f +[NSException raise:format:] + 0
	3   Foundation                          0x00007fff2077056a -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 191
	4   Flutter                             0x000000010a196246 -[FlutterEngine sendOnChannel:message:binaryReply:] + 544
	5   background_locator                  0x000000010a0df5dc -[BackgroundLocatorPlugin sendLocationEvent:] + 316
	6   background_locator                  0x000000010a0df290 -[BackgroundLocatorPlugin prepareLocationMap:] + 128
	7   background_locator                  0x000000010a0df360 -[BackgroundLocatorPlugin locationManager:didUpdateLocations:] + 160
	8   CoreLocation                        0x00007fff234082eb CLClientStopVehicleHeadingUpdates + 79384
	9   CoreLocation                        0x00007fff234074ff CLClientStopVehicleHeadingUpdates + 75820
	10  CoreLocation                        0x00007fff233ef909 CLClientInvalidate + 1479
	11  CoreFoundation                      0x00007fff2038f120 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
	12  CoreFoundation                      0x00007fff2038e534 __CFRunLoopDoBlocks + 434
	13  CoreFoundation                      0x00007fff20388f44 __CFRunLoopRun + 899
	14  CoreFoundation                      0x00007fff203886d6 CFRunLoopRunSpecific + 567
	15  GraphicsServices                    0x00007fff2bededb3 GSEventRunModal + 139
	16  UIKitCore                           0x00007fff24690e0b -[UIApplication _run] + 912
	17  UIKitCore                           0x00007fff24695cbc UIApplicationMain + 101
	18  Runner                              0x0000000108be7feb main + 75
	19  libdyld.dylib                       0x00007fff202593e9 start + 1
	20  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Sending a message before the FlutterEngine has been run.'
terminating with uncaught exception of type NSException
```

I think it happened because the plugin was calling FlutterMethodChannel during the initialization of the flutter engine.

[FlutterEngine.mm#L798-L799](https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm#L798-L799)

so, I changed to ignore that exception.
 