### PR TITLE
Send result if already running

### DIFF
--- a/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/BackgroundLocatorPlugin.kt
@@ -39,6 +39,7 @@ class BackgroundLocatorPlugin
             if (PreferencesManager.isServiceRunning(context)) {
                 // The service is running already
                 Log.d("BackgroundLocatorPlugin", "Locator service is already running")
+                result?.success(true)
                 return
             }
 


### PR DESCRIPTION
Send result if already running so at flutter side it won't wait for the result or else it will keep waiting for the result and will not execute code written after it at dart side.