### PR TITLE
Arrange iOS initCallback parameters format to Android one.

### DIFF
--- a/ios/Classes/BackgroundLocatorPlugin.m
+++ b/ios/Classes/BackgroundLocatorPlugin.m
@@ -196,13 +196,9 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     [PreferencesManager setCallbackHandle:callback key:kCallbackKey];
     
-    NSDictionary *initData = @{
-                     kArgInitCallback : @(initCallback),
-                     kArgInitDataCallback: initialDataDictionary
-                     };
     InitPluggable *initPluggable = [[InitPluggable alloc] init];
     [initPluggable setCallback:initCallback];
-    [initPluggable onServiceStart:initData];
+    [initPluggable onServiceStart:initialDataDictionary];
     
     DisposePluggable *disposePluggable = [[DisposePluggable alloc] init];
     [disposePluggable setCallback:disposeCallback];


### PR DESCRIPTION
related #246 .

I noticed the parameter format of `initCallback` is different between iOS and Android, so I arranged it.
I think this is a bug, but I'm not sure because it looked like the original code was written intentionally.
