### PR TITLE
Change processing order on initialize FlutterEngine

### DIFF
--- a/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderExtension.kt
+++ b/android/src/main/kotlin/rekab/app/background_locator/IsolateHolderExtension.kt
@@ -19,15 +19,15 @@ internal fun IsolateHolderService.startLocatorService(context: Context) {
         this.context = context
         if (IsolateHolderService.backgroundEngine == null) {
 
+            // We need flutter engine to handle callback, so if it is not available we have to create a
+            // Flutter engine without any view
+            IsolateHolderService.backgroundEngine = FlutterEngine(context)
+
             val callbackHandle = context.getSharedPreferences(
                     Keys.SHARED_PREFERENCES_KEY,
                     Context.MODE_PRIVATE)
                     .getLong(Keys.CALLBACK_DISPATCHER_HANDLE_KEY, 0)
             val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
-
-            // We need flutter engine to handle callback, so if it is not available we have to create a
-            // Flutter engine without any view
-            IsolateHolderService.backgroundEngine = FlutterEngine(context)
 
             val args = DartExecutor.DartCallback(
                     context.assets,


### PR DESCRIPTION
I've got some crash report via Firebase Crashlytics on production app, like `Fatal Exception: java.lang.UnsatisfiedLinkError`.
And found related issue: #296.

I tried reproduce that crash, but this was sometimes reproducible and sometimes not, so I was struggling to solve it...
I found [this issue comment](https://github.com/flutter/flutter/issues/69250#issuecomment-737857707) while googling, and I think it applies to this plugin as well, so I created this PR.

** Currently v1.6.12 is broken, so this PR is based on v1.6.6 commit.