### PR TITLE
fix bug with zero ARG_PROVIDER

### DIFF
--- a/lib/location_dto.dart
+++ b/lib/location_dto.dart
@@ -40,7 +40,7 @@ class LocationDto {
       json[Keys.ARG_HEADING],
       json[Keys.ARG_TIME],
       isLocationMocked,
-      json[Keys.ARG_PROVIDER],
+      json[Keys.ARG_PROVIDER]??"",
     );
   }
 


### PR DESCRIPTION
fix bug with zero ARG_PROVIDER

In my case, the provider is set to Null and because of this I cannot get the current coordinates, checking for zero and substituting an empty string solves this problem