### PR TITLE
fix json decoding error when provider is null

### DIFF
--- a/lib/location_dto.dart
+++ b/lib/location_dto.dart
@@ -12,7 +12,7 @@ class LocationDto {
   final double heading;
   final double time;
   final bool isMocked;
-  final String provider;
+  final String? provider;
 
   LocationDto._(
     this.latitude,


### PR DESCRIPTION
In `LocationDto`, `provider` is declared as such:

```dart
final String provider;
```

, with the assumption that it is always non-null. However, when receiving locations (tested on an iOS device), `provider` can be null, thus throwing an exception.

This PR makes the field optional.